### PR TITLE
Save default values for sub-fields

### DIFF
--- a/src/Fieldtypes/Collapse.php
+++ b/src/Fieldtypes/Collapse.php
@@ -75,6 +75,6 @@ class Collapse extends Fieldtype
           return $field->fieldtype()->process($field->defaultValue());
         });
 
-        return collect($defaults)->merge($data)->ray()->all();
+        return collect($defaults)->merge($data)->all();
     }
 }

--- a/src/Fieldtypes/Collapse.php
+++ b/src/Fieldtypes/Collapse.php
@@ -71,6 +71,10 @@ class Collapse extends Fieldtype
      */
     public function process($data)
     {
-        return $data;
+        $defaults = $this->fields()->all()->map(function ($field) {
+          return $field->fieldtype()->process($field->defaultValue());
+        });
+
+        return collect($defaults)->merge($data)->ray()->all();
     }
 }


### PR DESCRIPTION
Presently, when saving a field that has default values, those default values will not be saved to to the record. This creates odd behavior and requires some rather strange workarounds.

AFAIK, this should fix the problem. But I haven't figured out if there's any other side effects to doing this here. So far, everything seems to be working fine.